### PR TITLE
Make client logging best-effort

### DIFF
--- a/src/helpers/logClientEvent.tsx
+++ b/src/helpers/logClientEvent.tsx
@@ -120,7 +120,9 @@ const logClientEvent: LogFunction = async (opts) => {
       },
     });
   } catch (err) {
-    return undefined;
+    // Logging is best-effort. Keep the signal without breaking the user flow.
+    // eslint-disable-next-line no-console
+    console.warn('Failed to log client event', err);
   }
 };
 

--- a/src/helpers/logClientEvent.tsx
+++ b/src/helpers/logClientEvent.tsx
@@ -66,59 +66,62 @@ const logClientEvent: LogFunction = async (opts) => {
     }
   }
 
-  // Send to server
-  return visitServerEndpoint({
-    path: LOG_ROUTE_PATH,
-    method: 'POST',
-    params: {
-      context: (
-        typeof opts.context === 'string'
-          ? opts.context
-          : (
-            ((opts.context as any) ?? {})._
-            ?? LogBuiltInMetadata.Context.Uncategorized
-          )
-      ),
-      subcontext: (
-        opts.subcontext
-        ?? LogBuiltInMetadata.Context.Uncategorized
-      ),
-      level: (
-        opts.level
-        ?? LogLevel.Info
-      ),
-      tags: JSON.stringify(opts.tags ?? []),
-      metadata: JSON.stringify(metadata),
-      errorMessage: (
-        (opts as any).error
-          ? (opts as any).error.message
-          : undefined
-      ),
-      errorCode: (
-        (opts as any).error
-          ? (opts as any).error.code
-          : undefined
-      ),
-      errorStack: (
-        (opts as any).error
-          ? (opts as any).error.stack
-          : undefined
-      ),
-      target: (
-        (opts as any).action
-          ? (
-            (opts as any).target
-            ?? LogBuiltInMetadata.Target.NoTarget
-          )
-          : undefined
-      ),
-      action: (
-        (opts as any).action
-          ? (opts as any).action
-          : undefined
-      ),
-    },
-  });
+  try {
+    return await visitServerEndpoint({
+      path: LOG_ROUTE_PATH,
+      method: 'POST',
+      params: {
+        context: (
+          typeof opts.context === 'string'
+            ? opts.context
+            : (
+              ((opts.context as any) ?? {})._
+              ?? LogBuiltInMetadata.Context.Uncategorized
+            )
+        ),
+        subcontext: (
+          opts.subcontext
+          ?? LogBuiltInMetadata.Context.Uncategorized
+        ),
+        level: (
+          opts.level
+          ?? LogLevel.Info
+        ),
+        tags: JSON.stringify(opts.tags ?? []),
+        metadata: JSON.stringify(metadata),
+        errorMessage: (
+          (opts as any).error
+            ? (opts as any).error.message
+            : undefined
+        ),
+        errorCode: (
+          (opts as any).error
+            ? (opts as any).error.code
+            : undefined
+        ),
+        errorStack: (
+          (opts as any).error
+            ? (opts as any).error.stack
+            : undefined
+        ),
+        target: (
+          (opts as any).action
+            ? (
+              (opts as any).target
+              ?? LogBuiltInMetadata.Target.NoTarget
+            )
+            : undefined
+        ),
+        action: (
+          (opts as any).action
+            ? (opts as any).action
+            : undefined
+        ),
+      },
+    });
+  } catch (err) {
+    return undefined as any;
+  }
 };
 
 export default logClientEvent;

--- a/src/helpers/logClientEvent.tsx
+++ b/src/helpers/logClientEvent.tsx
@@ -120,7 +120,7 @@ const logClientEvent: LogFunction = async (opts) => {
       },
     });
   } catch (err) {
-    return undefined as any;
+    return undefined;
   }
 };
 


### PR DESCRIPTION
## Summary
- Catch `logClientEvent()` transport failures so best-effort client logging does not create unhandled promise rejections.

## Why
Cypress was failing during cleanup/relaunch because an in-flight `/dce-reactkit/log` request could be canceled by navigation. Since many logging calls are intentionally fire-and-forget, the rejected logging promise surfaced as an uncaught app error.
